### PR TITLE
DB初期化スクリプトの修正

### DIFF
--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -1,12 +1,11 @@
 -- テーブル作成
 -- ユーザマスタ
-CREATE TABLE m_user
+CREATE TABLE users
 (
-    id                        int unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
-    created_at                datetime            DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
-    updated_at                datetime            DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
-    deleted_at                datetime            DEFAULT NULL COMMENT '削除日時',
-    PRIMARY KEY (id)
+    user_id  int unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
+    email    string NOT NULL COMMENT 'email',
+    password string NOT NULL COMMENT 'password',
+    PRIMARY KEY (user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci comment ='ユーザマスタ'

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -31,12 +31,13 @@ CREATE TABLE posts
 -- イイネトランザクション
 CREATE TABLE likes
 (
+    like_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'like_id',
     post_id int unsigned NOT NULL COMMENT 'イイネ先post_id',
     user_id int unsigned NOT NULL COMMENT 'イイネをしたユーザのuser_id',
     date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'イイネした日付時刻',
     FOREIGN KEY (post_id) REFERENCES posts (post_id),
     FOREIGN KEY (user_id) REFERENCES users (user_id),
-    PRIMARY KEY (post_id)
+    PRIMARY KEY (like_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -3,8 +3,8 @@
 CREATE TABLE users
 (
     user_id  int unsigned NOT NULL AUTO_INCREMENT COMMENT 'user_id',
-    email    string NOT NULL COMMENT 'email',
-    password string NOT NULL COMMENT 'password',
+    email    varchar(100) NOT NULL COMMENT 'email',
+    password varchar(100) NOT NULL COMMENT 'password',
     PRIMARY KEY (user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -16,7 +16,7 @@ CREATE TABLE posts
 (
     post_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'post_id',
     user_id int unsigned NOT NULL COMMENT 'user_id',
-    body    string NOT NULL COMMENT 'body',
+    body    text NOT NULL COMMENT 'body',
     date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'date',
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
@@ -25,7 +25,7 @@ CREATE TABLE posts
 ;
 
 -- イイネマスタ
-CREATE TABLE posts
+CREATE TABLE likes
 (
     post_id int unsigned NOT NULL COMMENT 'post_id',
     user_id int unsigned NOT NULL COMMENT 'user_id',

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -20,6 +20,7 @@ CREATE TABLE posts
     user_id int unsigned NOT NULL COMMENT '投稿者user_id',
     body    text         NOT NULL COMMENT '本文',
     date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT '投稿日付',
+    FOREIGN KEY (user_id) REFERENCES users (user_id),
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -33,6 +34,8 @@ CREATE TABLE likes
     post_id int unsigned NOT NULL COMMENT 'イイネ先post_id',
     user_id int unsigned NOT NULL COMMENT 'イイネをしたユーザのuser_id',
     date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'イイネした日付時刻',
+    FOREIGN KEY (post_id) REFERENCES posts (post_id),
+    FOREIGN KEY (user_id) REFERENCES users (user_id),
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -3,8 +3,8 @@
 CREATE TABLE users
 (
     user_id  int unsigned NOT NULL AUTO_INCREMENT COMMENT 'user_id',
-    email    varchar(254) NOT NULL COMMENT 'email',
-    password varchar(100) NOT NULL COMMENT 'password',
+    email    varchar(254) NOT NULL COMMENT 'ログイン用email',
+    password varchar(100) NOT NULL COMMENT 'ログイン用password',
     PRIMARY KEY (user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -15,9 +15,9 @@ CREATE TABLE users
 CREATE TABLE posts
 (
     post_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'post_id',
-    user_id int unsigned NOT NULL COMMENT 'user_id',
-    body    text NOT NULL COMMENT 'body',
-    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'date',
+    user_id int unsigned NOT NULL COMMENT '投稿者user_id',
+    body    text NOT NULL COMMENT '本文',
+    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT '投稿日付',
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
@@ -27,9 +27,9 @@ CREATE TABLE posts
 -- イイネトランザクション
 CREATE TABLE likes
 (
-    post_id int unsigned NOT NULL COMMENT 'post_id',
-    user_id int unsigned NOT NULL COMMENT 'user_id',
-    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'date',
+    post_id int unsigned NOT NULL COMMENT 'イイネ先post_id',
+    user_id int unsigned NOT NULL COMMENT 'イイネをしたユーザのuser_id',
+    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'イイネした日付時刻',
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -36,7 +36,7 @@ CREATE TABLE likes
     liked_at datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'イイネした日付時刻',
     FOREIGN KEY (post_id) REFERENCES posts (post_id),
     FOREIGN KEY (user_id) REFERENCES users (user_id),
-    PRIMARY KEY (post_id, user_id)
+    PRIMARY KEY (user_id, post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -8,7 +8,8 @@ CREATE TABLE users
     PRIMARY KEY (user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment ='ユーザトランザクション'
+  COLLATE = utf8mb4_unicode_ci
+    COMMENT = 'ユーザトランザクション'
 ;
 
 -- 投稿トランザクション
@@ -16,12 +17,13 @@ CREATE TABLE posts
 (
     post_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'post_id',
     user_id int unsigned NOT NULL COMMENT '投稿者user_id',
-    body    text NOT NULL COMMENT '本文',
+    body    text         NOT NULL COMMENT '本文',
     date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT '投稿日付',
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment ='投稿トランザクション'
+  COLLATE = utf8mb4_unicode_ci
+    COMMENT = '投稿トランザクション'
 ;
 
 -- イイネトランザクション
@@ -33,5 +35,6 @@ CREATE TABLE likes
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment ='イイネトランザクション'
+  COLLATE = utf8mb4_unicode_ci
+    COMMENT = 'イイネトランザクション'
 ;

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -2,11 +2,25 @@
 -- ユーザマスタ
 CREATE TABLE users
 (
-    user_id  int unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
+    user_id  int unsigned NOT NULL AUTO_INCREMENT COMMENT 'user_id',
     email    string NOT NULL COMMENT 'email',
     password string NOT NULL COMMENT 'password',
     PRIMARY KEY (user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci comment ='ユーザマスタ'
+;
+
+
+-- 投稿マスタ
+CREATE TABLE posts
+(
+    post_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'post_id',
+    user_id int unsigned NOT NULL COMMENT 'user_id',
+    body    string NOT NULL COMMENT 'body',
+    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'date',
+    PRIMARY KEY (post_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci comment ='投稿マスタ'
 ;

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -1,5 +1,5 @@
 -- テーブル作成
--- ユーザマスタ
+-- ユーザトランザクション
 CREATE TABLE users
 (
     user_id  int unsigned NOT NULL AUTO_INCREMENT COMMENT 'user_id',
@@ -8,10 +8,10 @@ CREATE TABLE users
     PRIMARY KEY (user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment ='ユーザマスタ'
+  COLLATE = utf8mb4_unicode_ci comment ='ユーザトランザクション'
 ;
 
--- 投稿マスタ
+-- 投稿トランザクション
 CREATE TABLE posts
 (
     post_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'post_id',
@@ -21,10 +21,10 @@ CREATE TABLE posts
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment ='投稿マスタ'
+  COLLATE = utf8mb4_unicode_ci comment ='投稿トランザクション'
 ;
 
--- イイネマスタ
+-- イイネトランザクション
 CREATE TABLE likes
 (
     post_id int unsigned NOT NULL COMMENT 'post_id',
@@ -33,5 +33,5 @@ CREATE TABLE likes
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
-  COLLATE = utf8mb4_unicode_ci comment ='イイネマスタ'
+  COLLATE = utf8mb4_unicode_ci comment ='イイネトランザクション'
 ;

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -16,10 +16,10 @@ CREATE TABLE users
 -- 投稿トランザクション
 CREATE TABLE posts
 (
-    post_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'post_id',
-    user_id int unsigned NOT NULL COMMENT '投稿者user_id',
-    body    text         NOT NULL COMMENT '本文',
-    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT '投稿日時',
+    post_id   int unsigned NOT NULL AUTO_INCREMENT COMMENT 'post_id',
+    user_id   int unsigned NOT NULL COMMENT '投稿者user_id',
+    body      text         NOT NULL COMMENT '本文',
+    posted_at datetime DEFAULT CURRENT_TIMESTAMP COMMENT '投稿日時',
     FOREIGN KEY (user_id) REFERENCES users (user_id),
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB
@@ -31,9 +31,9 @@ CREATE TABLE posts
 -- イイネトランザクション
 CREATE TABLE likes
 (
-    post_id int unsigned NOT NULL COMMENT 'イイネ先post_id',
-    user_id int unsigned NOT NULL COMMENT 'イイネをしたユーザのuser_id',
-    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'イイネした日付時刻',
+    post_id  int unsigned NOT NULL COMMENT 'イイネ先post_id',
+    user_id  int unsigned NOT NULL COMMENT 'イイネをしたユーザのuser_id',
+    liked_at datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'イイネした日付時刻',
     FOREIGN KEY (post_id) REFERENCES posts (post_id),
     FOREIGN KEY (user_id) REFERENCES users (user_id),
     PRIMARY KEY (post_id, user_id)

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -4,7 +4,7 @@ CREATE TABLE users
 (
     user_id    int unsigned NOT NULL AUTO_INCREMENT COMMENT 'user_id',
     email      varchar(254) NOT NULL COMMENT 'ログイン用email',
-    password   varchar(100) NOT NULL COMMENT 'ログイン用password',
+    password   text         NOT NULL COMMENT 'ログイン用password',
     created_at datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
     PRIMARY KEY (user_id)
 ) ENGINE = InnoDB

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -2,9 +2,10 @@
 -- ユーザトランザクション
 CREATE TABLE users
 (
-    user_id  int unsigned NOT NULL AUTO_INCREMENT COMMENT 'user_id',
-    email    varchar(254) NOT NULL COMMENT 'ログイン用email',
-    password varchar(100) NOT NULL COMMENT 'ログイン用password',
+    user_id    int unsigned NOT NULL AUTO_INCREMENT COMMENT 'user_id',
+    email      varchar(254) NOT NULL COMMENT 'ログイン用email',
+    password   varchar(100) NOT NULL COMMENT 'ログイン用password',
+    created_at datetime DEFAULT CURRENT_TIMESTAMP COMMENT '登録日時',
     PRIMARY KEY (user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -3,7 +3,7 @@
 CREATE TABLE users
 (
     user_id  int unsigned NOT NULL AUTO_INCREMENT COMMENT 'user_id',
-    email    varchar(100) NOT NULL COMMENT 'email',
+    email    varchar(254) NOT NULL COMMENT 'email',
     password varchar(100) NOT NULL COMMENT 'password',
     PRIMARY KEY (user_id)
 ) ENGINE = InnoDB

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -19,7 +19,7 @@ CREATE TABLE posts
     post_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'post_id',
     user_id int unsigned NOT NULL COMMENT '投稿者user_id',
     body    text         NOT NULL COMMENT '本文',
-    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT '投稿日付',
+    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT '投稿日時',
     FOREIGN KEY (user_id) REFERENCES users (user_id),
     PRIMARY KEY (post_id)
 ) ENGINE = InnoDB

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -36,7 +36,7 @@ CREATE TABLE likes
     liked_at datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'イイネした日付時刻',
     FOREIGN KEY (post_id) REFERENCES posts (post_id),
     FOREIGN KEY (user_id) REFERENCES users (user_id),
-    PRIMARY KEY (user_id, post_id)
+    PRIMARY KEY (post_id, user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -31,13 +31,12 @@ CREATE TABLE posts
 -- イイネトランザクション
 CREATE TABLE likes
 (
-    like_id int unsigned NOT NULL AUTO_INCREMENT COMMENT 'like_id',
     post_id int unsigned NOT NULL COMMENT 'イイネ先post_id',
     user_id int unsigned NOT NULL COMMENT 'イイネをしたユーザのuser_id',
     date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'イイネした日付時刻',
     FOREIGN KEY (post_id) REFERENCES posts (post_id),
     FOREIGN KEY (user_id) REFERENCES users (user_id),
-    PRIMARY KEY (like_id)
+    PRIMARY KEY (post_id, user_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci

--- a/flyway/sql/V1.0.0__init.sql
+++ b/flyway/sql/V1.0.0__init.sql
@@ -11,7 +11,6 @@ CREATE TABLE users
   COLLATE = utf8mb4_unicode_ci comment ='ユーザマスタ'
 ;
 
-
 -- 投稿マスタ
 CREATE TABLE posts
 (
@@ -23,4 +22,16 @@ CREATE TABLE posts
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci comment ='投稿マスタ'
+;
+
+-- イイネマスタ
+CREATE TABLE posts
+(
+    post_id int unsigned NOT NULL COMMENT 'post_id',
+    user_id int unsigned NOT NULL COMMENT 'user_id',
+    date    datetime DEFAULT CURRENT_TIMESTAMP COMMENT 'date',
+    PRIMARY KEY (post_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci comment ='イイネマスタ'
 ;


### PR DESCRIPTION
ER図をもとにDBの初期化スクリプトの修正を行いました。

ER図は下記の通りです

```mermaid
erDiagram

users {
    int user_id
    varchar email
    text password
    datetime created_at
}

posts {
    int post_id
    int user_id
    text body
    datetime posted_at
}

likes {
    int post_id
    int user_id
    datetime liked_at
}

users ||--o{ posts: ""

posts ||--o{ likes: ""

users ||--o{ likes: ""
```

動作確認方法は

1. docker-compose up -d database
2. docker-compose run --rm flyway-clean
3. docker-compose run --rm flyway-migrate

です。