### PR TITLE
投稿一覧機能の実装

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+    implementation("org.thymeleaf.extras:thymeleaf-extras-java8time")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/src/main/kotlin/com/example/SaladBoard/controller/PostController.kt
+++ b/src/main/kotlin/com/example/SaladBoard/controller/PostController.kt
@@ -32,7 +32,7 @@ class PostController(val postService: PostService) {
     /**
      * 投稿一覧画面を返す
      */
-    @RequestMapping(value = ["/home"], method = [RequestMethod.GET])
+    @RequestMapping(value = ["/", "/home"], method = [RequestMethod.GET])
     fun showAllPosts(model: Model): String {
         model.addAttribute("allPosts", postService.returnAllPosts())
         return "home"

--- a/src/main/kotlin/com/example/SaladBoard/controller/PostController.kt
+++ b/src/main/kotlin/com/example/SaladBoard/controller/PostController.kt
@@ -28,4 +28,13 @@ class PostController(val postService: PostService) {
         postService.savePost(body = postForm)
         return PostForm(body = postForm.body)
     }
+
+    /**
+     * 投稿一覧画面を返す
+     */
+    @RequestMapping(value = ["/home"], method = [RequestMethod.GET])
+    fun showAllPosts(model: Model): String {
+        model.addAttribute("allPosts", postService.returnAllPosts())
+        return "home"
+    }
 }

--- a/src/main/kotlin/com/example/SaladBoard/service/PostService.kt
+++ b/src/main/kotlin/com/example/SaladBoard/service/PostService.kt
@@ -14,4 +14,11 @@ class PostService(val postRepository: PostRepository) {
         val entity = Post(body = body.body)
         postRepository.save(entity)
     }
+
+    /**
+     * 投稿を一括で返す
+     */
+    fun returnAllPosts(): MutableList<Post> {
+        return postRepository.findAll()
+    }
 }

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -12,16 +12,14 @@ This is home page.
 <hr>
 
 <tr th:each="post:${allPosts}" th:object="${post}">
-    <td>body :</td>
-    <td th:text="*{body}"></td>
-    <br>
-    <td>user_id :</td>
-    <td th:text="*{userId}"></td>
-    <br>
-    <td>posted_at :</td>
-    <td th:text="*{postedAt}"></td>
-    <br>
-    <hr>
+    <div style="padding: 10px; margin-bottom: 10px; border: 1px solid #333333;">
+        <div style="display: flex;flex-wrap: wrap">
+            <div>user_id :<span th:text="*{userId}"></span></div>
+            <div style="margin-left: auto">posted_at :<span
+                    th:text="${#temporals.format(post.postedAt, 'yyyy/MM/dd')}"></span></div>
+            <div style="width: 100%">body :<span th:text="*{body}"></span></div>
+        </div>
+    </div>
 </tr>
 
 </body>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>SaladBoard</title>
+</head>
+<body>
+This is home page.
+
+<hr>
+
+<tr th:each="post:${allPosts}" th:object="${post}">
+    <td>body :</td>
+    <td th:text="*{body}"></td>
+    <br>
+    <td>user_id :</td>
+    <td th:text="*{userId}"></td>
+    <br>
+    <td>posted_at :</td>
+    <td th:text="*{postedAt}"></td>
+    <br>
+    <hr>
+</tr>
+
+</body>
+</html>


### PR DESCRIPTION


を実装した。

## チケットへのリンク
* なし

## やったこと
* 投稿一覧画面
* 投稿一覧を取得する処理
の実装

## やらないこと
* 

## できるようになること（ユーザ目線）
* 投稿一覧を見ること

## できなくなること（ユーザ目線）
* なし

## 動作確認
1. 起動 [やりかた](https://qiita.com/t-iguchi/items/ba323f4d418d158d2116#5-%E5%AE%9F%E8%A1%8C%E3%81%97%E3%81%A6%E7%A2%BA%E8%AA%8D%E3%81%99%E3%82%8B)
3. make init_db
5. [ここ](http://localhost:8080/post) にアクセス
7. テキストボックスに何かを入力する
9. Post をクリック
11. [ここ](http://localhost:8080/post) にアクセス
13. 「4.」に入力した投稿が表示される


## その他
### 特にレビューしてもらいたいところ
* 

### 残タスク(余裕があったら)
* アカウント機能
